### PR TITLE
add useNativeDriver to Ripple animations

### DIFF
--- a/lib/mdl/Ripple.js
+++ b/lib/mdl/Ripple.js
@@ -160,6 +160,7 @@ class Ripple extends Component {
     // scaling up the ripple layer
     this._rippleAni = Animated.timing(this._animatedRippleScale, {
       toValue: 1,
+      useNativeDriver: true,
       duration: this.props.rippleDuration || 200,
     });
 
@@ -184,6 +185,7 @@ class Ripple extends Component {
       // hide the ripple layer
       Animated.timing(this._animatedAlpha, {
         toValue: 0,
+        useNativeDriver: true,
         duration: this.props.maskDuration || 200,
       }).start();
 


### PR DESCRIPTION
This allows the animation to occur in a native thread so that JavaScript code execution resulting from an "onPress" does not block the animation's completion.

https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html